### PR TITLE
Remove code that is incompatible with PHP 7.2

### DIFF
--- a/inc/files.class.php
+++ b/inc/files.class.php
@@ -274,9 +274,6 @@ class File extends FilesCommon {
 
     function delete() {
         $result = parent::_delete($this);
-        if ($result !== false) {
-            unset ($this);
-        }
         return $result;
     }
 


### PR DESCRIPTION
The line "unset($this)" is not valid under PHP 7.2.

Removing this code does not seem to have any side effects that I can see, and allows TaskPaperPlus to run under PHP 7.2